### PR TITLE
Modify tag ID generation, update schema

### DIFF
--- a/src/Data/Repository/TagRepository.ts
+++ b/src/Data/Repository/TagRepository.ts
@@ -1,8 +1,12 @@
-import { doc, setDoc } from 'firebase/firestore';
+import { arrayUnion, doc, setDoc } from 'firebase/firestore';
+import { Tag } from '../../Common/interfaces';
 import { db } from '../DataSource/firebase';
 
-export async function createTag(tagName: string) {
-    const result = await setDoc(doc(db, "tags", tagName), { });
+export async function createTag(newTag: Tag, userId: string) {
+    const result = await setDoc(doc(db, "tags", newTag.id), { 
+        name: newTag.tagName,
+        authors: arrayUnion(newTag.id)
+    });
 
     return result;
 }

--- a/src/Data/Repository/TagRepository.ts
+++ b/src/Data/Repository/TagRepository.ts
@@ -1,12 +1,30 @@
-import { arrayUnion, doc, setDoc } from 'firebase/firestore';
+import { arrayUnion, doc, setDoc, updateDoc } from 'firebase/firestore';
 import { Tag } from '../../Common/interfaces';
 import { db } from '../DataSource/firebase';
 
 export async function createTag(newTag: Tag, userId: string) {
-    const result = await setDoc(doc(db, "tags", newTag.id), { 
-        name: newTag.tagName,
-        authors: arrayUnion(newTag.id)
-    });
+    const tagDocRef = doc(db, "tags", newTag.id);
+
+    let data = {};
+    let result = null;
+
+    try {
+        // Attempt to update the document with given tag ID
+        data = {
+            authors: arrayUnion(userId)
+        }
+        result = await updateDoc(tagDocRef, data);
+    } catch(error: any) {
+        
+        // There was no document to update so we create a new one
+        if (error.code === "not-found") {
+            data = {
+                name: newTag.tagName,
+                authors: arrayUnion(userId) 
+            }
+            result = await setDoc(tagDocRef, data);
+        }
+    }
 
     return result;
 }

--- a/src/Domain/UseCase/Flashcard/CreateFlashcard.ts
+++ b/src/Domain/UseCase/Flashcard/CreateFlashcard.ts
@@ -1,6 +1,6 @@
 import { createFlashcard } from '../../../Data/Repository/FlashcardRepository';
 import { Card } from '../../../Common/interfaces';
 
-export async function CreateFlashcardUseCase(flashcard: Card, tagNames: Array<string>, userId: string) {
-    return await createFlashcard(flashcard, tagNames, userId);
+export async function CreateFlashcardUseCase(flashcard: Card, tagIds: Array<string>, userId: string) {
+    return await createFlashcard(flashcard, tagIds, userId);
 }

--- a/src/Domain/UseCase/Tag/CreateTag.ts
+++ b/src/Domain/UseCase/Tag/CreateTag.ts
@@ -1,5 +1,6 @@
+import { Tag } from '../../../Common/interfaces';
 import { createTag } from '../../../Data/Repository/TagRepository';
 
-export async function CreateTagUseCase(tagName: string) {
-    return await createTag(tagName);
+export async function CreateTagUseCase(newTag: Tag, userId: string) {
+    return await createTag(newTag, userId);
 }

--- a/src/Presentation/Views/CreateFlashcards/CreateFlashcards.tsx
+++ b/src/Presentation/Views/CreateFlashcards/CreateFlashcards.tsx
@@ -11,7 +11,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { auth } from '../../../Data/DataSource/firebase';
 
 import './create-flashcards.css';
-import { onAuthStateChanged, User } from 'firebase/auth';
+import { onAuthStateChanged } from 'firebase/auth';
 import Loading from '../../Components/Loading/Loading';
 
 function CreateFlashcards() {

--- a/src/Presentation/Views/CreateFlashcards/CreateFlashcardsViewModel.ts
+++ b/src/Presentation/Views/CreateFlashcards/CreateFlashcardsViewModel.ts
@@ -17,7 +17,6 @@ export default function CreateFlashcardsViewModel() {
         if (remainingTags === 0 && remainingFlashcards === 0) {
             setIsLoading(false);
             alert("Card set has been saved");
-            window.location.reload();
         }
     }, [remainingTags, remainingFlashcards]);
 
@@ -50,63 +49,52 @@ export default function CreateFlashcardsViewModel() {
 
         // Filtering out tags to remove duplicates in the form
         tags.forEach(tag => {
-            let name = tag.tagName.trim().replace(/[\s\.\[\]\*`]+/g, " ").trim();
-            console.log(name);
-            console.log(name.length);
+
+            // Trimming unnecessary extra spaces
+            let name = tag.tagName.replace(/\s+/g, " ").trim();
             
             // Verify that name isn't a duplicate AND verify that name isn't only spaces or blank after regex and trimming
             if (uniqueTagNames.indexOf(name) === -1 && (name.search(/^\s+/g) !== 0 && name.length !== 0)) {
                 
                 // Call function to convert the given tag name to a readable id
                 let newId = generateReadableId(name);
-
-                console.log(newId);
                 
                 // If generated ID is empty
-                if (newId.length > 0 && uniqueTagIds.indexOf(newId) == -1) {
+                if (newId.length > 0 && uniqueTagIds.indexOf(newId) === -1) {
                     uniqueTagNames.push(name);
                     uniqueTagIds.push(newId);
                     newTags.push({ id: newId, tagName: name });
                 }
-            } else {
-                console.log("skipped tags")
             }
         });
-        
-        console.log("Tag Names:");
-        console.log(uniqueTagNames);
-        console.log("Tag IDs:");
-        console.log(uniqueTagIds);
-        console.log("New Tags:");
-        console.log(newTags);
         
 
         // Initializing remaining tags and flashcards
         setRemainingTags(newTags.length);
         setRemainingFlashcards(flashcards.length);
-        // setIsLoading(true);
+        setIsLoading(true);
 
-        // if (user !== null && user !== undefined) {
-        //     newTags.forEach(async (newTag) => {
-        //         try {
-        //             await CreateTagUseCase(newTag, user.uid).then(() => {
-        //                 setRemainingTags((remainingTags) => remainingTags - 1);
-        //             });
-        //         } catch(error: any) {
-        //             console.log(error);
-        //         }
-        //     });
+        if (user !== null && user !== undefined) {
+            newTags.forEach(async (newTag) => {
+                try {
+                    await CreateTagUseCase(newTag, user.uid).then(() => {
+                        setRemainingTags((remainingTags) => remainingTags - 1);
+                    });
+                } catch(error: any) {
+                    console.log(error);
+                }
+            });
     
-        //     flashcards.forEach(async (flashcard) => {
-        //         try {
-        //             await CreateFlashcardUseCase(flashcard, tagNames, user.uid).then(() => {
-        //                 setRemainingFlashcards((remainingFlashcards) => remainingFlashcards -1);
-        //             });
-        //         } catch(error: any) {
-        //             console.log(error);
-        //         }   
-        //     });
-        // }
+            flashcards.forEach(async (flashcard) => {
+                try {
+                    await CreateFlashcardUseCase(flashcard, uniqueTagIds, user.uid).then(() => {
+                        setRemainingFlashcards((remainingFlashcards) => remainingFlashcards -1);
+                    });
+                } catch(error: any) {
+                    console.log(error);
+                }   
+            });
+        }
     }
 
     function generateReadableId(name: string) {
@@ -129,16 +117,6 @@ export default function CreateFlashcardsViewModel() {
             event.preventDefault();
             return true;
         }
-
-        // Quick fix to prevent invalid characters from being uploaded to tag ids
-        // if (event.key === "/" || 
-        //     event.key === "." || 
-        //     event.key === "[" || 
-        //     event.key === "]" ||
-        //     event.key === "*" ||
-        //     event.key === "`") {
-        //     event.preventDefault();
-        // }
 
         return false;
     }


### PR DESCRIPTION
- This PR modifies how we save the tag IDs. Now there will be no issues with users creating a tag name (that initially was saved as a tag ID) that contained characters not allowed for Firebase document IDs. 
- All tag IDs are generated based on the tag names entered by the user. The name is converted to a lowercase-kebab casing format which filters out the characters not allowed for Firebase document IDs. (i.e. "ER / ERR" --> "er-err", "Computer Science" --> "computer-science"
- No duplicate tags are sent to the database. The user who created/used the tag gets appended to the `authors` array in the tag document.
- The tag name field is decided by the first person who created the tag or if we developers decided to change the name.

closes #29 