### PR TITLE
feat: Edit and Delete Flashcards

### DIFF
--- a/src/Data/Repository/FlashcardRepository.ts
+++ b/src/Data/Repository/FlashcardRepository.ts
@@ -1,5 +1,5 @@
 import { db } from '../DataSource/firebase';
-import { doc, setDoc} from 'firebase/firestore';
+import { doc, setDoc, deleteDoc, updateDoc} from 'firebase/firestore';
 import { Card } from '../../Common/interfaces';
 import { query, where, collection, getDocs } from 'firebase/firestore';
 
@@ -30,5 +30,11 @@ export async function getFlashcardsByCurrentUserAndTags(userId: string, tagsSele
 export async function getFlashcardsByTags(tagsSelected: Array<string>) {
     const q = query(collection(db, "flashcards"), where("tags", "array-contains-any", tagsSelected));
     const result = await getDocs(q);
+    return result;
+}
+
+// delete flashcard ()
+export async function deleteFlashcard(flashcardId: string){;
+    const result = await deleteDoc(doc(db, "flashcards", flashcardId));
     return result;
 }

--- a/src/Data/Repository/FlashcardRepository.ts
+++ b/src/Data/Repository/FlashcardRepository.ts
@@ -38,3 +38,12 @@ export async function deleteFlashcard(flashcardId: string){;
     const result = await deleteDoc(doc(db, "flashcards", flashcardId));
     return result;
 }
+
+// eidt flashcard ()
+export async function editFlashcard(flashcardId : string, updatedQuestion : string, updatedAnswer: string){
+    const result = await updateDoc(doc(db,"flashcards", flashcardId), {
+        question: updatedQuestion,
+        answer: updatedAnswer
+    });
+    return result;
+}

--- a/src/Domain/UseCase/Flashcard/DeleteFlashcard.ts
+++ b/src/Domain/UseCase/Flashcard/DeleteFlashcard.ts
@@ -1,1 +1,5 @@
-export {};
+import { deleteFlashcard } from "../../../Data/Repository/FlashcardRepository";
+
+export async function DeleteFlashcardUseCase(flashcardId: string){
+    return await deleteFlashcard(flashcardId);
+}

--- a/src/Domain/UseCase/Flashcard/EditFlashcard.ts
+++ b/src/Domain/UseCase/Flashcard/EditFlashcard.ts
@@ -1,0 +1,6 @@
+import { editFlashcard } from '../../../Data/Repository/FlashcardRepository';
+
+
+export async function EditFlashcardUseCase(flashcardId : string, updatedQuestion : string, updatedAnswer: string){
+    return await editFlashcard(flashcardId, updatedQuestion, updatedAnswer);
+}

--- a/src/Presentation/Views/ViewFlashcards/ViewFlashcards.tsx
+++ b/src/Presentation/Views/ViewFlashcards/ViewFlashcards.tsx
@@ -4,11 +4,14 @@ import { useNavigate } from 'react-router-dom';
 import { Formik, Form, Field, ErrorMessage } from 'formik';
 import { onAuthStateChanged } from 'firebase/auth';
 import { auth } from "../../../Data/DataSource/firebase";
-import Carousel from 'react-bootstrap/Carousel';
-import Card from '@mui/material/Card';
-import OffCanvas from 'react-bootstrap/Offcanvas';
-import TuneIcon from '@mui/icons-material/Tune';
 
+import Card from '@mui/material/Card';
+import TuneIcon from '@mui/icons-material/Tune';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import Carousel from 'react-bootstrap/Carousel';
+import OffCanvas from 'react-bootstrap/Offcanvas';
+import Modal from 'react-bootstrap/Modal';
 
 import './view-flashcards.css';
 
@@ -23,6 +26,11 @@ function ViewFlashcards() {
         checkboxInputs,
         carouselIndex,
         showFilterSettings,
+        onClickEnterEditCardMode,
+        showDeleteModal,
+        handleShowDeleteModal,
+        handleCloseDeleteModal,
+        onClickDeleteFlashcard,
         onClickHandleShowFilterSettings,
         onClickHandleCloseFilterSettings,
         onSelectNextCard,
@@ -56,6 +64,7 @@ function ViewFlashcards() {
     }, []); 
 
     return (
+        <>
         <div className='container'>
             <div className='row'>
                 {/* Tag Filters */}
@@ -109,7 +118,6 @@ function ViewFlashcards() {
                     </OffCanvas.Body>
                 </OffCanvas>
                 <div className='col'>
-
                     <div className='row'>
                         <div className='col'>
                             {/* TODO make into its own component */}
@@ -129,17 +137,28 @@ function ViewFlashcards() {
                                     }) :
                                     <span className='current-tag'>All tags</span>
                                 }
-                                <hr />
+                                
                             </div>
                             
                         </div>
                     </div>
+
+                    <hr />
 
                     <div className='row'>
                         <div className='col'>
                             {/* TODO make into its own componenet */}
                             {/* Flashcard carousel */}
                             <Carousel indicators={false} interval={null} activeIndex={carouselIndex} onSelect={onSelectNextCard}>
+                                {
+                                    flashcards.length === 0 &&
+                                    <Carousel.Item>
+                                        <div className='flashcard-view view-cards'>
+                                            <p>There are no flashcards in this set.</p>
+                                        </div>
+                                    </Carousel.Item>
+                                }
+
                                 {
                                     // display each flashcard
                                     flashcards.map((flashcard, index) => {
@@ -155,11 +174,13 @@ function ViewFlashcards() {
                                                     {/* <p>{flip ? flashcard.answer : flashcard.question}</p> */}
                                                     {/* <h3>{ flashcard.answer }</h3> */}
                                                 </div>
+                                                
                                             </Carousel.Item>
                                             
                                         );
                                     })
                                 }
+                                
                             </Carousel>
                         </div>
                     </div>
@@ -171,22 +192,56 @@ function ViewFlashcards() {
                         <div className='col'>
                             {/* Flashcard */}
                             {/* TODO make into its own component */}
-                            <p className='m-2 view-cards-title'>Cards in this set</p>
                             {
-                                flashcards.map((flashcard, index) => {
-                                    return (
-                                        <div className='m-2 row view-cards' key={flashcard.id}>
-                                            <p className='p-3 col-5 question-section'>{ flashcard.question }</p>
-                                            <p className='p-3 col-7 answer-section'>{ flashcard.answer }</p>
-                                        </div>
-                                    );
-                                })
+                                flashcards.length > 0 &&
+                                <>
+                                    <p className='m-2 view-cards-title'>Cards in this set</p>
+                                    {
+                                        flashcards.map((flashcard, index) => {
+                                            if (flashcard.userId === auth.currentUser?.uid) {
+                                                return (
+                                                    <div className='m-2 row view-cards' key={flashcard.id}>
+                                                        <p className='p-3 col-5 question-section'>{ flashcard.question }</p>
+                                                        <p className='p-3 col-5 answer-section'>{ flashcard.answer }</p>
+                                                        <p className='p-3 col-1 edit-icon' onClick={onClickEnterEditCardMode}><EditIcon /></p>
+                                                        <p className='p-3 col-1 delete-card-icon' onClick={() => handleShowDeleteModal(flashcard.id)}><DeleteIcon /></p>
+                                                    </div>
+                                                );
+                                            } else {
+                                                return (
+                                                    <div className='m-2 row view-cards' key={flashcard.id}>
+                                                        <p className='p-3 col-5 question-section'>{ flashcard.question }</p>
+                                                        <p className='p-3 col-7 answer-section'>{ flashcard.answer }</p>
+                                                    </div>
+                                                );
+                                            }
+                                        })
+                                    }
+                                </>
                             }
+                            
                         </div>
                     </div>
                 </div>
             </div>
         </div>
+        <Modal
+            show={showDeleteModal}
+            onHide={handleCloseDeleteModal}
+            centered
+        >
+            <Modal.Header closeButton>
+                <Modal.Title>Delete this flashcard?</Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+                <p>Are you sure you want to delete this card?</p>
+            </Modal.Body>
+            <Modal.Footer>
+                <button className='btn btn-secondary' onClick={handleCloseDeleteModal}>Cancel</button>
+                <button className='btn btn-danger' onClick={onClickDeleteFlashcard}>Confirm</button>
+            </Modal.Footer>
+        </Modal>
+        </>
     );
 }
 

--- a/src/Presentation/Views/ViewFlashcards/ViewFlashcards.tsx
+++ b/src/Presentation/Views/ViewFlashcards/ViewFlashcards.tsx
@@ -25,8 +25,10 @@ function ViewFlashcards() {
         currentTagNames,
         checkboxInputs,
         carouselIndex,
+        editMode,
         showFilterSettings,
         onClickEnterEditCardMode,
+        onKeyDownSaveChanges,
         showDeleteModal,
         handleShowDeleteModal,
         handleCloseDeleteModal,
@@ -201,9 +203,34 @@ function ViewFlashcards() {
                                             if (flashcard.userId === auth.currentUser?.uid) {
                                                 return (
                                                     <div className='m-2 row view-cards' key={flashcard.id}>
-                                                        <p className='p-3 col-5 question-section'>{ flashcard.question }</p>
-                                                        <p className='p-3 col-5 answer-section'>{ flashcard.answer }</p>
-                                                        <p className='p-3 col-1 edit-icon' onClick={onClickEnterEditCardMode}><EditIcon /></p>
+                                                        {
+                                                            !editMode[index] ?
+                                                            <>
+                                                                <p className='p-3 col-5 question-section'>{ flashcard.question }</p>
+                                                                <p className='p-3 col-5 answer-section'>{ flashcard.answer }</p>
+                                                            </> :
+                                                            <>
+                                                                <div className='p-3 col-5'>
+                                                                    <span
+                                                                        contentEditable
+                                                                        className='m-3 flashcard-input flashcard-question' 
+                                                                        role="textbox"
+                                                                        onKeyDown={(e) => onKeyDownSaveChanges(e, index, flashcard.id)}
+                                                                    >{flashcard.question}</span>
+                                                                </div>
+
+                                                                <div className='p-3 col-5'>
+                                                                    <span
+                                                                        contentEditable
+                                                                        className='m-3 flashcard-input flashcard-answer' 
+                                                                        role="textbox"
+                                                                        onKeyDown={(e) => onKeyDownSaveChanges(e, index, flashcard.id)}
+                                                                    >{flashcard.answer}</span>
+                                                                </div>
+                                                            </>
+                                                        }
+                                                        
+                                                        <p className='p-3 col-1 edit-icon' onClick={() => onClickEnterEditCardMode(index, flashcard.id)}><EditIcon /></p>
                                                         <p className='p-3 col-1 delete-card-icon' onClick={() => handleShowDeleteModal(flashcard.id)}><DeleteIcon /></p>
                                                     </div>
                                                 );

--- a/src/Presentation/Views/ViewFlashcards/ViewFlashcards.tsx
+++ b/src/Presentation/Views/ViewFlashcards/ViewFlashcards.tsx
@@ -1,11 +1,10 @@
 import useViewModel from './ViewFlashcardsViewModel';
-import { forwardRef, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Formik, Form, Field, ErrorMessage } from 'formik';
 import { onAuthStateChanged } from 'firebase/auth';
 import { auth } from "../../../Data/DataSource/firebase";
 
-import Card from '@mui/material/Card';
 import TuneIcon from '@mui/icons-material/Tune';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
@@ -27,9 +26,10 @@ function ViewFlashcards() {
         carouselIndex,
         editMode,
         showFilterSettings,
-        onClickEnterEditCardMode,
-        onKeyDownSaveChanges,
+        viewCardsRef,
         showDeleteModal,
+        onClickToggleEditMode,
+        onKeyDownSaveChanges,
         handleShowDeleteModal,
         handleCloseDeleteModal,
         onClickDeleteFlashcard,
@@ -43,7 +43,7 @@ function ViewFlashcards() {
     } = useViewModel();
 
     // Carousel Function
-    const authFlag = useRef(true); 
+    const authFlag = useRef(true);
 
     //Flip Function
     const [flip, setFlip] = useState(false);
@@ -165,24 +165,20 @@ function ViewFlashcards() {
                                     // display each flashcard
                                     flashcards.map((flashcard, index) => {
                                         return (
-                                            <Carousel.Item>
+                                            <Carousel.Item key={flashcard.id}>
                                                 <div className={`flashcard-view view-cards ${flip ? 'flip' : ''}`} onClick={() => setFlip(!flip)}>
                                                     <div className="front">
-                                                        <p className='text-center'>{flashcard.question}</p>
+                                                        <p className='text-center database-text'>{flashcard.question}</p>
                                                     </div>
                                                     <div className="back">
-                                                        <p className='text-center'>{flashcard.answer}</p>
+                                                        <p className='text-center database-text'>{flashcard.answer}</p>
                                                     </div>
-                                                    {/* <p>{flip ? flashcard.answer : flashcard.question}</p> */}
-                                                    {/* <h3>{ flashcard.answer }</h3> */}
                                                 </div>
-                                                
                                             </Carousel.Item>
                                             
                                         );
                                     })
                                 }
-                                
                             </Carousel>
                         </div>
                     </div>
@@ -196,7 +192,7 @@ function ViewFlashcards() {
                             {/* TODO make into its own component */}
                             {
                                 flashcards.length > 0 &&
-                                <>
+                                <div ref={viewCardsRef}>
                                     <p className='m-2 view-cards-title'>Cards in this set</p>
                                     {
                                         flashcards.map((flashcard, index) => {
@@ -206,31 +202,33 @@ function ViewFlashcards() {
                                                         {
                                                             !editMode[index] ?
                                                             <>
-                                                                <p className='p-3 col-5 question-section'>{ flashcard.question }</p>
-                                                                <p className='p-3 col-5 answer-section'>{ flashcard.answer }</p>
+                                                                <p className='p-3 col-5 question-section database-text'>{ flashcard.question }</p>
+                                                                <p className='p-3 col-5 answer-section database-text'>{ flashcard.answer }</p>
                                                             </> :
                                                             <>
-                                                                <div className='p-3 col-5'>
+                                                                <div className='p-3 col-5 question-section'>
                                                                     <span
+                                                                        id={`${flashcard.id}-question`}
                                                                         contentEditable
-                                                                        className='m-3 flashcard-input flashcard-question' 
+                                                                        className='m-3 flashcard-input flashcard-question database-text' 
                                                                         role="textbox"
                                                                         onKeyDown={(e) => onKeyDownSaveChanges(e, index, flashcard.id)}
-                                                                    >{flashcard.question}</span>
+                                                                    >{ flashcard.question }</span>
                                                                 </div>
 
-                                                                <div className='p-3 col-5'>
+                                                                <div className='p-3 col-5 answer-section'>
                                                                     <span
+                                                                        id={`${flashcard.id}-answer`}
                                                                         contentEditable
-                                                                        className='m-3 flashcard-input flashcard-answer' 
+                                                                        className='m-3 flashcard-input flashcard-answer database-text' 
                                                                         role="textbox"
                                                                         onKeyDown={(e) => onKeyDownSaveChanges(e, index, flashcard.id)}
-                                                                    >{flashcard.answer}</span>
+                                                                    >{ flashcard.answer }</span>
                                                                 </div>
                                                             </>
                                                         }
                                                         
-                                                        <p className='p-3 col-1 edit-icon' onClick={() => onClickEnterEditCardMode(index, flashcard.id)}><EditIcon /></p>
+                                                        <p className='p-3 col-1 edit-icon' onClick={() => onClickToggleEditMode(index, flashcard.id)}><EditIcon /></p>
                                                         <p className='p-3 col-1 delete-card-icon' onClick={() => handleShowDeleteModal(flashcard.id)}><DeleteIcon /></p>
                                                     </div>
                                                 );
@@ -244,7 +242,7 @@ function ViewFlashcards() {
                                             }
                                         })
                                     }
-                                </>
+                                </div>
                             }
                             
                         </div>

--- a/src/Presentation/Views/ViewFlashcards/ViewFlashcardsViewModel.ts
+++ b/src/Presentation/Views/ViewFlashcards/ViewFlashcardsViewModel.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef, MouseEvent } from 'react';
+import { useEffect, useState, useRef, MouseEvent, KeyboardEvent } from 'react';
 import { Card, Tag, FilterForm } from '../../../Common/interfaces';
 import { auth } from '../../../Data/DataSource/firebase';
 import { DocumentData } from 'firebase/firestore';
@@ -32,6 +32,7 @@ export default function ViewFlashcardsViewModel() {
 
     const [showDeleteModal, setShowDeleteModal] = useState(false);
     const [currentFlashcardFocus, setCurrentFlashcardFocus] = useState("");
+    const [editMode, setEditMode] = useState<Array<boolean>>([]);
 
     function onSelectNextCard(selectedIndex: number) {
         setCarouselIndex(selectedIndex);
@@ -51,6 +52,7 @@ export default function ViewFlashcardsViewModel() {
 
         if (auth.currentUser) {
             setFlashcards([]);
+            setEditMode([]);
 
             if (sessionStorage.getItem("showOnlyCurrentUser") !== null) {
                 
@@ -249,6 +251,8 @@ export default function ViewFlashcardsViewModel() {
                             ...prevFlashcards,
                             { id: doc.id, ...doc.data() }
                         ]);
+
+                        initializeEditModes()
                     });
                 });
             } catch (error: any) {
@@ -266,6 +270,8 @@ export default function ViewFlashcardsViewModel() {
                         ...prevFlashcards,
                         { id: doc.id, ...doc.data() }
                     ]);
+
+                    initializeEditModes()
                 });
             });
         } catch (error: any) {
@@ -284,6 +290,8 @@ export default function ViewFlashcardsViewModel() {
                             ...prevFlashcards,
                             { id: doc.id, ...doc.data() }
                         ]);
+
+                        initializeEditModes()
                     });
                 });
                 
@@ -291,6 +299,13 @@ export default function ViewFlashcardsViewModel() {
                 console.log(error);
             }
         }
+    }
+
+    function initializeEditModes() {
+        setEditMode(prevEditModes => [
+            ...prevEditModes,
+            false
+        ]);
     }
 
     function onClickHandleShowFilterSettings() {
@@ -303,12 +318,27 @@ export default function ViewFlashcardsViewModel() {
         console.log(tags);
     }
 
-    function onClickEnterEditCardMode() {
+    function onClickEnterEditCardMode(index: number, flashcardId: string) {
+        let newEditModes = [...editMode];
+        newEditModes[index] = true;
+        setEditMode(newEditModes);
+    }
+
+    function exitEditMode(index: number) {
+        let newEditModes = [...editMode];
+        newEditModes[index] = false;
+        setEditMode(newEditModes);
+    }
+
+
+    function saveChanges(index: number, flashcardId: string) {
 
     }
 
-    function onClickExitEditCardMode() {
-
+    function onKeyDownSaveChanges(event: KeyboardEvent<Element>, index: number, flashcardId: string) {
+        if (event.key === "Enter") {
+            event.preventDefault();
+        }
     }
 
     function handleShowDeleteModal(flashcardId: string) {
@@ -345,8 +375,10 @@ export default function ViewFlashcardsViewModel() {
         carouselIndex,
         showFilterSettings,
         onClickEnterEditCardMode,
+        editMode,
         showDeleteModal,
         handleShowDeleteModal,
+        onKeyDownSaveChanges,
         handleCloseDeleteModal,
         onClickDeleteFlashcard,
         onClickHandleShowFilterSettings,

--- a/src/Presentation/Views/ViewFlashcards/ViewFlashcardsViewModel.ts
+++ b/src/Presentation/Views/ViewFlashcards/ViewFlashcardsViewModel.ts
@@ -8,6 +8,7 @@ import { GetAllTagsUseCase } from '../../../Domain/UseCase/Tag/GetAllTags';
 import { GetFlashcardsByCurrentUserUseCase } from '../../../Domain/UseCase/Flashcard/GetFlashcardsByCurrentUser';
 import { GetFlashcardsByCurrentUserAndTagsUseCase } from '../../../Domain/UseCase/Flashcard/GetFlashcardsByCurrentUserAndTags';
 import { GetFlashcardsByTagsUseCase } from '../../../Domain/UseCase/Flashcard/GetFlashcardsByTags';
+import { DeleteFlashcardUseCase } from '../../../Domain/UseCase/Flashcard/DeleteFlashcard';
 
 import * as Yup from 'yup';
 
@@ -28,6 +29,9 @@ export default function ViewFlashcardsViewModel() {
     });
     const checkboxInputs = useRef<HTMLDivElement>(null);
     const [showFilterSettings, setShowFilterSettings] = useState(false);
+
+    const [showDeleteModal, setShowDeleteModal] = useState(false);
+    const [currentFlashcardFocus, setCurrentFlashcardFocus] = useState("");
 
     function onSelectNextCard(selectedIndex: number) {
         setCarouselIndex(selectedIndex);
@@ -299,6 +303,38 @@ export default function ViewFlashcardsViewModel() {
         console.log(tags);
     }
 
+    function onClickEnterEditCardMode() {
+
+    }
+
+    function onClickExitEditCardMode() {
+
+    }
+
+    function handleShowDeleteModal(flashcardId: string) {
+        setShowDeleteModal(true);
+        setCurrentFlashcardFocus(flashcardId);
+    }
+
+    function handleCloseDeleteModal() {
+        setShowDeleteModal(false);
+        setCurrentFlashcardFocus("");
+    }
+
+    async function onClickDeleteFlashcard() {
+        if (auth.currentUser) {
+            try {
+                await DeleteFlashcardUseCase(currentFlashcardFocus).then((response) => {
+                    let upadatedFlashcards = flashcards.filter(flashcard => flashcard.id !== currentFlashcardFocus);
+                    setFlashcards(upadatedFlashcards);
+                    handleCloseDeleteModal();
+                });
+            } catch (error: any) {
+                console.log(error);
+            }
+        }
+    }
+
     return {
         flashcards,
         tags,
@@ -308,6 +344,11 @@ export default function ViewFlashcardsViewModel() {
         checkboxInputs,
         carouselIndex,
         showFilterSettings,
+        onClickEnterEditCardMode,
+        showDeleteModal,
+        handleShowDeleteModal,
+        handleCloseDeleteModal,
+        onClickDeleteFlashcard,
         onClickHandleShowFilterSettings,
         onClickHandleCloseFilterSettings,
         onSelectNextCard,

--- a/src/Presentation/Views/ViewFlashcards/view-flashcards.css
+++ b/src/Presentation/Views/ViewFlashcards/view-flashcards.css
@@ -89,3 +89,7 @@
 .delete-card-icon {
     color: #ba1a1a;
 }
+
+.database-text {
+    white-space: pre-wrap;
+}

--- a/src/Presentation/Views/ViewFlashcards/view-flashcards.css
+++ b/src/Presentation/Views/ViewFlashcards/view-flashcards.css
@@ -79,3 +79,12 @@
     border: none;
     border-radius: 5px;
 }
+
+.edit-icon, .delete-card-icon {
+    padding: 5px;
+    text-align: center;
+}
+
+.delete-card-icon {
+    color: #ba1a1a;
+}

--- a/src/Presentation/Views/ViewFlashcards/view-flashcards.css
+++ b/src/Presentation/Views/ViewFlashcards/view-flashcards.css
@@ -83,6 +83,7 @@
 .edit-icon, .delete-card-icon {
     padding: 5px;
     text-align: center;
+    cursor: pointer;
 }
 
 .delete-card-icon {


### PR DESCRIPTION
This PR implements the features of allowing users to edit the contents of their own flashcards or deleting them as a whole.

**Major Changes**
- Included an edit button to change a particular card to edit mode.
- Upon pressing the enter key or pressing the edit button again, the changes get saved to the database.
- Included a delete button on each of the users card.
- After pressing the delete button, a modal will prompt the user if they want to confirm the deletion of the card. If they confirm, the card is removed from the database and automatically removed from the client view.
- Users are only given the option to edit or delete their own cards.

closes #25 