### PR TITLE
fix: Incorrect invalid form error

### DIFF
--- a/src/Presentation/Views/CreateFlashcards/CreateFlashcards.tsx
+++ b/src/Presentation/Views/CreateFlashcards/CreateFlashcards.tsx
@@ -74,7 +74,7 @@ function CreateFlashcards() {
                                                             <span 
                                                                 id={`${tag.id}`}
                                                                 contentEditable
-                                                                className={ getIn(errors, `tags.[${index}]`) ? "m-3 tag-input tag-error" : "m-3 tag-input" }
+                                                                className={ getIn(errors, `tags.[${index}].name`) ? "m-3 tag-input tag-error" : "m-3 tag-input" }
                                                                 role="textbox"
                                                                 onKeyDown={onKeyDownPreventEnter}
                                                                 onInput={(e) => setFieldValue(`tags.[${index}].name`, e.currentTarget.innerText)}

--- a/src/Presentation/Views/CreateFlashcards/CreateFlashcardsViewModel.ts
+++ b/src/Presentation/Views/CreateFlashcards/CreateFlashcardsViewModel.ts
@@ -28,7 +28,7 @@ export default function CreateFlashcardsViewModel() {
     const validationSchema = Yup.object().shape({
         tags: Yup.array().of(
             Yup.object().shape({
-                tagName: Yup.string().required("Add a tag")
+                name: Yup.string().required("Add a tag")
             })
         ).min(1, "Please provide at least one tag"),
         flashcards: Yup.array().of(


### PR DESCRIPTION
This PR fixes the bug where users couldn't create cards even though everything was valid.

**Changes**
* The field tagName in the validationSchema needed to be changed to just name.
* The error detection to change the styling needed to specify that we're looking for errors in the name field.

closes #35